### PR TITLE
Vrtu 638 window location issue

### DIFF
--- a/modules/desktop/src/main/java/com/ncc/savior/desktop/xpra/application/swing/SwingXpraWindowManager.java
+++ b/modules/desktop/src/main/java/com/ncc/savior/desktop/xpra/application/swing/SwingXpraWindowManager.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (C) 2019 Next Century Corporation
- * 
+ *
  * This file may be redistributed and/or modified under either the GPL
  * 2.0 or 3-Clause BSD license. In addition, the U.S. Government is
  * granted government purpose rights. For details, see the COPYRIGHT.TXT
  * file at the root of this project.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301, USA.
- * 
+ *
  * SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
  */
 package com.ncc.savior.desktop.xpra.application.swing;

--- a/modules/desktop/src/main/java/com/ncc/savior/desktop/xpra/protocol/packet/dto/HelloPacket.java
+++ b/modules/desktop/src/main/java/com/ncc/savior/desktop/xpra/protocol/packet/dto/HelloPacket.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (C) 2019 Next Century Corporation
- * 
+ *
  * This file may be redistributed and/or modified under either the GPL
  * 2.0 or 3-Clause BSD license. In addition, the U.S. Government is
  * granted government purpose rights. For details, see the COPYRIGHT.TXT
  * file at the root of this project.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301, USA.
- * 
+ *
  * SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
  */
 package com.ncc.savior.desktop.xpra.protocol.packet.dto;

--- a/modules/virtue-admin/src/main/java/com/ncc/savior/virtueadmin/infrastructure/mixed/PooledXenVmProvider.java
+++ b/modules/virtue-admin/src/main/java/com/ncc/savior/virtueadmin/infrastructure/mixed/PooledXenVmProvider.java
@@ -85,7 +85,7 @@ public class PooledXenVmProvider implements IXenVmProvider {
 			IVpcSubnetProvider vpcSubnetProvider, IActiveVirtueDao xenVmDao,
 			CompletableFutureServiceProvider serviceProvider, String xenAmi, String xenLoginUser, String xenKeyName,
 			InstanceType xenInstanceType, String iamRoleName, Collection<String> securityGroupsNames, int poolSize) {
-		this.pool = new LinkedBlockingDeque<VirtualMachine>(poolSize * 2);
+		this.pool = new LinkedBlockingDeque<VirtualMachine>();
 		this.serverId = serverIdProvider.getServerId();
 		this.ec2Wrapper = ec2Wrapper;
 		this.vpcSubnetProvider = vpcSubnetProvider;


### PR DESCRIPTION
Fixed:

- Windows initially being off screen will now snap to the default monitor
- Windows moved entirely to a monitor with negative coordinates will now be snapped to the default monitor instead of being unresponsive.
- fixed potential error when changing xen pool sizes, the queue would not be able to support the change